### PR TITLE
Fix the 'undefined variable' notice

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug/Plugin/Database.php
+++ b/library/ZFDebug/Controller/Plugin/Debug/Plugin/Database.php
@@ -141,7 +141,7 @@ class ZFDebug_Controller_Plugin_Debug_Plugin_Database
             if ($profiles = $adapter->getProfiler()->getQueryProfiles()) {
                 $adapter->getProfiler()->setEnabled(false);
                 if (1 < count($this->_db)) {
-                    $html .= '<h4>Adapter '.$name.'</h4>';
+                    $queries .= '<h4>Adapter '.$name.'</h4>';
                 }
                 $queries .='<table cellspacing="0" cellpadding="0" width="100%">';
                 foreach ($profiles as $profile) {


### PR DESCRIPTION
A notice appears when I use more than one Database adapter.

Notice: Undefined variable: html in /library/ZFDebug/Controller/Plugin/Debug/Plugin/Database.php on line 144

I've replaced $html by $queries which is used in this method to return a profile information.
