### PR TITLE
Enable auth panel

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug.php
+++ b/library/ZFDebug/Controller/Plugin/Debug.php
@@ -58,6 +58,7 @@ class ZFDebug_Controller_Plugin_Debug extends Zend_Controller_Plugin_Abstract
      * @var array
      */
     public static $standardPlugins = array(
+        'Auth',
         'Cache', 
         'Html', 
         'Database', 


### PR DESCRIPTION
Why this plugin is not defined as standard, and keep source in master? This panel works very well IHMO.
