### PR TITLE
This bar can only be displayed only in a html page

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug.php
+++ b/library/ZFDebug/Controller/Plugin/Debug.php
@@ -215,6 +215,12 @@ class ZFDebug_Controller_Plugin_Debug extends Zend_Controller_Plugin_Abstract
         if ($this->getRequest()->isXmlHttpRequest()) {
             return;
         }
+
+        $contentType = $this->getRequest()->getHeader('Content-Type');
+	if (false === $contentType || false === strpos($contentType, 'html')) {
+	    return;
+	}
+
         $disable = Zend_Controller_Front::getInstance()->getRequest()->getParam('ZFDEBUG_DISABLE');
         if (isset($disable)) {
             return;


### PR DESCRIPTION
A action controller can generate a different content type as XML. Currently, we must disable the toolbar by hand using the disable parameter.
