### PR TITLE
Add option to disable plugin in certain modules

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug.php
+++ b/library/ZFDebug/Controller/Plugin/Debug.php
@@ -49,7 +49,8 @@ class ZFDebug_Controller_Plugin_Debug extends Zend_Controller_Plugin_Abstract
             'Variables' => null,
             'Time' => null,
             'Memory' => null),
-        'image_path'        => null
+        'image_path'        => null,
+        'exclude_modules'   => array()
     );
 
     /**
@@ -155,6 +156,10 @@ class ZFDebug_Controller_Plugin_Debug extends Zend_Controller_Plugin_Abstract
         if (isset($options['plugins'])) {
             $this->_options['plugins'] = $options['plugins'];
         }
+        
+        if (isset($options['exclude_modules'])) {
+            $this->_options['exclude_modules'] = $options['exclude_modules'];
+        }
         return $this;
     }
 
@@ -213,7 +218,9 @@ class ZFDebug_Controller_Plugin_Debug extends Zend_Controller_Plugin_Abstract
      */
     public function dispatchLoopShutdown()
     {
-        if ($this->getRequest()->isXmlHttpRequest()) {
+    	if (in_array($this->getRequest()->getModuleName(), $this->_options['exclude_modules'])
+            || $this->getRequest()->isXmlHttpRequest()
+        ) {
             return;
         }
 


### PR DESCRIPTION
If you are using different MVC modules it may be useful to disable the
plugin in specific modules. Since you usually register the plugin at
bootstrap, there is no way to tell the requested module at that time. 
Adding an option 'exclude_modules' can overcome this problem by checking in
the dispatchLoopShutdown with something like:

``` php
if (in_array($this->getRequest()->getModuleName(),
$this->_options['exclude_modules'])) {
    return;
}
```

[google code issue 46](https://code.google.com/p/zfdebug/issues/detail?id=46)
