### PR TITLE
user defined constants are to sorted alphabetically now

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug/Plugin/Constants.php
+++ b/library/ZFDebug/Controller/Plugin/Debug/Plugin/Constants.php
@@ -78,6 +78,8 @@ class ZFDebug_Controller_Plugin_Debug_Plugin_Constants extends ZFDebug_Controlle
         $constants = get_defined_constants(true);
         $this->_userConstants = $constants['user'];
 
+        ksort($this->_userConstants);
+
         $count = count($this->_userConstants);
         return "Constants ($count)";
     }


### PR DESCRIPTION
I made some minor improvement on the constant plugin.

user defined constants are to sorted alphabetically now
