### PR TITLE
Add support for composer dependency management tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The available plugins at this point are:
 for custom memory measurements.
   * Log: Timing information of current request, time spent in action controller and custom timers. Also average, min and max time for requests.
   * Variables: View variables, request info and contents of `$_COOKIE`, `$_POST` and `$_SESSION`
-  
+
 Installation & Usage
 ------------
 To install, place the folder 'ZFDebug' in your library path, next to the Zend
@@ -27,10 +27,10 @@ folder. Then add the following method to your bootstrap class (in ZF1.8+):
 	    $autoloader->registerNamespace('ZFDebug');
 
 	    $options = array(
-	        'plugins' => array('Variables', 
-	                           'Database' => array('adapter' => $db), 
+	        'plugins' => array('Variables',
+	                           'Database' => array('adapter' => $db),
 	                           'File' => array('basePath' => '/path/to/project'),
-	                           'Cache' => array('backend' => $cache->getBackend()), 
+	                           'Cache' => array('backend' => $cache->getBackend()),
 	                           'Exception')
 	    );
 	    $debug = new ZFDebug_Controller_Plugin_Debug($options);
@@ -39,5 +39,20 @@ folder. Then add the following method to your bootstrap class (in ZF1.8+):
 	    $frontController = $this->getResource('frontController');
 	    $frontController->registerPlugin($debug);
 	}
+
+Using Composer
+--------------
+You may now install ZFDebug using the dependency management tool Composer.
+
+To use ZFDebug with Composer, add the following to the require list in your
+project's composer.json file:
+
+	"require": {
+	    "jokkedk/ZFDebug": "1.6.1"
+	},
+
+Run the install command to resolve and download the dependencies:
+
+	php composer.phar install
 
 Further documentation will follow as the github move progresses.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "jokkedk/ZFDebug",
+    "description": "ZFDebug is a plugin for the Zend Framework for PHP5, providing useful debug information displayed in a small bar at the bottom of every page.",
+    "type": "library",
+    "homepage": "https://github.com/jokkedk/ZFDebug",
+    "license": "BSD-3-Clause",
+    "autoload": {
+        "psr-0": {
+            "ZFDebug_": "library/"
+        }
+    },
+    "require": {
+        "zendframework/zendframework1": "1.*"
+    },
+    "authors": [
+        {
+            "name": "Joakim Nygård",
+            "homepage": "http://jokke.dk",
+            "role": "Developer"
+        },
+        {
+            "name": "Andreas Pankratz",
+            "homepage": "http://www.bangal.de",
+            "role": "Contributor"
+        }
+    ]
+}


### PR DESCRIPTION
Add support for using composer with ZFDebug. This allows project maintainers to easily include ZFDebug into their codebase. Once this is merged, the package needs to be published on packagist.org. Publishing can be accomplished by creating a packagist.org account, clicking 'Submit Package', and providing the github.com repository URL for ZFDebug.
