### PR TITLE
Add library directory to include path in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "ZFDebug_": "library/"
         }
     },
+    "include-path": [
+        "library/"
+    ],
     "require": {
         "zendframework/zendframework1": "1.*"
     },


### PR DESCRIPTION
ZFDebug contains require_once() calls for it's own files, which expect
that the ZFDebug library path be part of the PHP include path. Update
composer so that the proper library path configuration is in place.
