### PR TITLE
fixed count() used with non countable parameter

### DIFF
--- a/library/ZFDebug/Controller/Plugin/Debug/Plugin/Database.php
+++ b/library/ZFDebug/Controller/Plugin/Debug/Plugin/Database.php
@@ -50,7 +50,7 @@ class ZFDebug_Controller_Plugin_Debug_Plugin_Database
      */
     public function __construct(array $options = array())
     {
-        if (!isset($options['adapter']) || !count($options['adapter'])) {
+        if (!isset($options['adapter']) || empty($options['adapter'])) {
             if (Zend_Db_Table_Abstract::getDefaultAdapter()) {
                 $this->_db[0] = Zend_Db_Table_Abstract::getDefaultAdapter();
                 if (isset($options['backtrace']) && $options['backtrace']) {


### PR DESCRIPTION
Hi, man.

The issue I aim to fix is `Warning: count(): Parameter must be an array or an object that implements Countable`.

I'm aware this is related only to [PHP >= 7.2](https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types), but I think it's a costless and safe improvement, worth to be implemented.

Thanks in advance!

Francesco